### PR TITLE
Fix datetime bug

### DIFF
--- a/templates/wikiweb/index.html
+++ b/templates/wikiweb/index.html
@@ -4,7 +4,6 @@
     <title>Wikisual - Wikipedia Visualized</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="static/bootstrap3/dist/css/bootstrap.min.css">
     <link rel="stylesheet" href="static/css/readable.min.css">
     <!-- 1. Load libraries -->
      <!-- Polyfill(s) for older browsers -->

--- a/wikicollector/services.py
+++ b/wikicollector/services.py
@@ -1,16 +1,15 @@
+from typing import Union
+
 from django.db.models import Count, F
+import udatetime as datetime
 
 from wikicollector.models import RecentChange
-
-import udatetime as datetime
 
 
 class RecentChangeService(object):
 
     def get_top_field_by_date(self, field: str,
-                                    date: str=datetime.utcnow()
-                                                      .date()
-                                                      .isoformat(),
+                                    date: Union[str, None]=None,
                                     top_count: int = 10,
                                     return_query=False) -> list:
         """
@@ -19,6 +18,9 @@ class RecentChangeService(object):
 
         :return: list in format  of [{field: str, total: int}]
         """
+        if date is None:
+            date = datetime.utcnow().date().isoformat()
+
         exclude = {field: ''}
 
         query = RecentChange.objects.all() \
@@ -37,10 +39,7 @@ class RecentChangeService(object):
 
     def get_top_user_by_date_filtered(self,
                                       top_count: int = 10,
-                                      date: str=datetime
-                                        .utcnow()
-                                        .date()
-                                        .isoformat()) -> list:
+                                      date: Union[str, None]=None) -> list:
         """
         get the top users who made changes in RecentChange table for today
         today is in UTC timezone
@@ -57,10 +56,7 @@ class RecentChangeService(object):
 
     def get_top_countries_by_date(self,
                                   top_count: int = 10,
-                                  date: str=datetime
-                                      .utcnow()
-                                      .date()
-                                      .isoformat()) -> list:
+                                  date: Union[str, None]=None) -> list:
         """
         get the top countries from RecentChange table for today
         today is in UTC timezone
@@ -73,10 +69,7 @@ class RecentChangeService(object):
 
     def get_top_titles_by_date_filtered(self,
                                         top_count: int = 10,
-                                        date: str=datetime
-                                            .utcnow()
-                                            .date()
-                                            .isoformat()) -> list:
+                                        date: Union[str, None]=None) -> list:
         """
         get the top edits in RecentChange table for today
         today is in UTC timezone


### PR DESCRIPTION
having date generated from datetime module in default parameter will persist across execution.
which means the same date will be used forever until a new object is created.

to fix this:
1. set the default date as None
2. also accept string
3. if None, create today's date in utc
